### PR TITLE
Removes faulty regular expression.

### DIFF
--- a/processes.json
+++ b/processes.json
@@ -1,0 +1,5 @@
+{
+    "name": "map-playground",
+    "cwd": ".",
+    "script": "./dist/server.js"
+}

--- a/processes.json
+++ b/processes.json
@@ -1,5 +1,0 @@
-{
-    "name": "map-playground",
-    "cwd": ".",
-    "script": "./dist/server.js"
-}

--- a/static/js/mapp.js
+++ b/static/js/mapp.js
@@ -97,7 +97,7 @@ function getGistId() {
     if (/^[a-fA-F0-9]+$/.test(getGistId())) {
         $('body').addClass('gist-viewable');
         $('body').removeClass('gist-saveable');
-        $('#view-gist').attr('href', 'https://gist.github.com/' + window.location.pathname.match(/[0-9a-f]+/));
+        $('#view-gist').attr('href', 'https://gist.github.com/' + getGistId());
     }
 })();
 


### PR DESCRIPTION
You had a function `getGistId()` already, wonder why you had that (broken) regular expression in there.
